### PR TITLE
Fix errors when opening categories

### DIFF
--- a/main.py
+++ b/main.py
@@ -817,7 +817,7 @@ def get_app_key():
 
 
 def get_app_id_and_app_key():
-    tv = "http://areena.yle.fi/tv"
+    tv = "http://areena.yle.fi/tv/ohjelmat/sarjat"
     response = get_url_response(tv).read()
     start = response.index('window.ohjelmat')
     start = response.index('applicationId:', start)


### PR DESCRIPTION
Categories listing was broken because the addon couldn't find application_id and application_key anymore in www.areena.yle.fi/tv. I changed the address to www.areena.yle.fi/tv/ohjelmat/sarjat where the keys can be found again.