### PR TITLE
Issue #42, Add support for seasons, episode.hash sort

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.areena"
-       version="3.0.0"
+       version="3.0.1"
        name="YLE Areena (unofficial)"
        provider-name="Toni Lappalainen">
     <requires>

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -302,3 +302,15 @@ msgstr ""
 msgctxt "#32072"
 msgid "NOT AVAILABLE"
 msgstr ""
+
+msgctxt "#32073"
+msgid "No sorting"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Go to series"
+msgstr ""
+
+msgctxt "#32075"
+msgid "episode.hash"
+msgstr ""

--- a/resources/language/Finnish/strings.po
+++ b/resources/language/Finnish/strings.po
@@ -302,3 +302,15 @@ msgstr "Lisää hakemisto"
 msgctxt "#32072"
 msgid "NOT AVAILABLE"
 msgstr "EI SAATAVILLA"
+
+msgctxt "#32073"
+msgid "No sorting"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Go to series"
+msgstr ""
+
+msgctxt "#32075"
+msgid "episode.hash"
+msgstr ""

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -302,3 +302,15 @@ msgstr "Skapa mapp"
 msgctxt "#32072"
 msgid "NOT AVAILABLE"
 msgstr "INTE TILLGÄNGLIG"
+
+msgctxt "#32073"
+msgid "No sorting"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Go to series"
+msgstr ""
+
+msgctxt "#32075"
+msgid "episode.hash"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,7 +5,7 @@
         <setting id="showClips" type="bool" label="32041" default="true" />
         <setting id="showExtraInfo" type="bool" label="32042" default="false" />
         <setting id="language" type="enum" label="32003" lvalues="32004|32005|32006" default="0" />
-        <setting id="sortMethod" type="enum" label="32014" lvalues="32015|32016|32017|32018|32019|32020|32021" default="6" />
+        <setting id="sortMethod" type="enum" label="32014" lvalues="32015|32016|32017|32018|32019|32020|32021|32073|32075" default="6" />
         <setting id="ascOrDesc" type="enum" label="32011" lvalues="32012|32013" default="1" />
     </category>
     <category label="32058">


### PR DESCRIPTION
First step for #42.

This splits series in seasons, if the season data is available through `series/items`. 
When used with the new sorting method, `episode.hash`, episodes are usually ordered properly.

Sometimes the season data is not available (Itse valtiaat, https://external.api.yle.fi/v1/series/items/1-50552097.json) and the old `list_series` is used as a fallback (`episode.hash` sort works with that too). I haven't figured out what to do when the season data is littered with likely duplicates with mostly empty seasons (Summeri, https://external.api.yle.fi/v1/series/items/1-3826506.json).

